### PR TITLE
[Patch] Adjust crafted item quality mapping and exceptions

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -117,7 +117,7 @@ function buildV1ItemInfo(itemid: string, desc: string) {
     [sdk.colors.Yellow]: sdk.items.quality.Rare,
     [sdk.colors.LightGold]: sdk.items.quality.Crafted,
     [sdk.colors.DarkGold]: sdk.items.quality.Unique,
-    [sdk.colors.Orange]: sdk.items.quality.Normal,
+    [sdk.colors.Orange]: sdk.items.quality.Crafted,
     [sdk.colors.Gray]: sdk.items.quality.Normal,
   };
 
@@ -139,6 +139,15 @@ function buildV1ItemInfo(itemid: string, desc: string) {
         return sdk.items.quality.Superior;
       }
       const quality = codeToQuality[code];
+      if (quality === sdk.items.quality.Crafted) {
+        if (
+          desc.includes("Rune") ||
+          desc.includes("Essence") ||
+          desc.includes("Token")
+        ) {
+          return sdk.items.quality.Normal;
+        }
+      }
       return quality ?? -1;
     })(),
     itemType: (() => {


### PR DESCRIPTION
This pull request updates the logic for determining item quality in the `buildV1ItemInfo` function to better handle items with the color orange and to correctly classify certain special items. The most important changes are:

**Quality Mapping Adjustments:**

* Changed the mapping for `sdk.colors.Orange` from `sdk.items.quality.Normal` to `sdk.items.quality.Crafted` in the `codeToQuality` object.

**Special Case Handling:**

* Added logic to reclassify items as `Normal` quality if their description includes "Rune", "Essence", or "Token", even if their color would otherwise indicate `Crafted` quality.