### PR TITLE
[Patch] Parse lvl/str/dex requirements for V1 items

### DIFF
--- a/src/components/InventoryGrid.tsx
+++ b/src/components/InventoryGrid.tsx
@@ -276,52 +276,52 @@ export const InventoryGrid: React.FC<InventoryGridProps> = memo(
           return false;
         }
 
+        if (ilvlFilter !== null) {
+          if (ilvlComparison === "gte" && item.ilvl < ilvlFilter) {
+            return false;
+          }
+          if (ilvlComparison === "lte" && item.ilvl > ilvlFilter) {
+            return false;
+          }
+          if (ilvlComparison === "eq" && item.ilvl !== ilvlFilter) {
+            return false;
+          }
+        }
+        if (levelReqFilter !== null) {
+          if (levelReqComparison === "gte" && item.lvlreq < levelReqFilter) {
+            return false;
+          }
+          if (levelReqComparison === "lte" && item.lvlreq > levelReqFilter) {
+            return false;
+          }
+          if (levelReqComparison === "eq" && item.lvlreq !== levelReqFilter) {
+            return false;
+          }
+        }
+        if (strReqFilter !== null) {
+          if (strReqComparison === "gte" && item.strreq < strReqFilter) {
+            return false;
+          }
+          if (strReqComparison === "lte" && item.strreq > strReqFilter) {
+            return false;
+          }
+          if (strReqComparison === "eq" && item.strreq !== strReqFilter) {
+            return false;
+          }
+        }
+        if (dexReqFilter !== null) {
+          if (dexReqComparison === "gte" && item.dexreq < dexReqFilter) {
+            return false;
+          }
+          if (dexReqComparison === "lte" && item.dexreq > dexReqFilter) {
+            return false;
+          }
+          if (dexReqComparison === "eq" && item.dexreq !== dexReqFilter) {
+            return false;
+          }
+        }
         // V2 Item filters (only apply to V2 items)
         if (isV2Item(item)) {
-          if (ilvlFilter !== null) {
-            if (ilvlComparison === "gte" && item.ilvl < ilvlFilter) {
-              return false;
-            }
-            if (ilvlComparison === "lte" && item.ilvl > ilvlFilter) {
-              return false;
-            }
-            if (ilvlComparison === "eq" && item.ilvl !== ilvlFilter) {
-              return false;
-            }
-          }
-          if (levelReqFilter !== null) {
-            if (levelReqComparison === "gte" && item.lvlreq < levelReqFilter) {
-              return false;
-            }
-            if (levelReqComparison === "lte" && item.lvlreq > levelReqFilter) {
-              return false;
-            }
-            if (levelReqComparison === "eq" && item.lvlreq !== levelReqFilter) {
-              return false;
-            }
-          }
-          if (strReqFilter !== null) {
-            if (strReqComparison === "gte" && item.strreq < strReqFilter) {
-              return false;
-            }
-            if (strReqComparison === "lte" && item.strreq > strReqFilter) {
-              return false;
-            }
-            if (strReqComparison === "eq" && item.strreq !== strReqFilter) {
-              return false;
-            }
-          }
-          if (dexReqFilter !== null) {
-            if (dexReqComparison === "gte" && item.dexreq < dexReqFilter) {
-              return false;
-            }
-            if (dexReqComparison === "lte" && item.dexreq > dexReqFilter) {
-              return false;
-            }
-            if (dexReqComparison === "eq" && item.dexreq !== dexReqFilter) {
-              return false;
-            }
-          }
           if (
             itemCodeFilter &&
             !item.code.toLowerCase().includes(itemCodeFilter.toLowerCase())
@@ -365,14 +365,7 @@ export const InventoryGrid: React.FC<InventoryGridProps> = memo(
           }
         } else {
           // For V1 items, skip if any V2-only filters are active
-          if (
-            ilvlFilter !== null ||
-            levelReqFilter !== null ||
-            strReqFilter !== null ||
-            dexReqFilter !== null ||
-            itemCodeFilter ||
-            statFilters.length > 0
-          ) {
+          if (itemCodeFilter || statFilters.length > 0) {
             return false;
           }
         }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,6 +32,7 @@ type V1InventoryItem = BaseInventoryItem & {
   sockets: number;
   gfx: number;
   color: number;
+  ilvl: number;
   lvlreq: number;
   strreq: number;
   dexreq: number;
@@ -496,6 +497,10 @@ export function mapApiItemToInventoryItem(
       sockets: itemInfo.sockets,
       gfx: itemInfo.gfx,
       color: itemInfo.color,
+      ilvl: itemInfo.ilvl,
+      lvlreq: itemInfo.lvlreq,
+      strreq: itemInfo.strreq,
+      dexreq: itemInfo.dexreq,
     } as V1InventoryItem;
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -367,6 +367,11 @@ function buildV1ItemInfo(itemid: string, desc: string) {
     })(),
     gfx: Number(gfx),
     color: Number(color),
+    ilvl: (() => {
+      // ilvl should always be in the first parentheses
+      const match = desc.match(/(\d+)/);
+      return match ? Number(match[1]) : 0;
+    })(),
     lvlreq: (() => {
       const match = desc.match(/Required Level: (\d+)/);
       return match ? Number(match[1]) : 0;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,6 +32,9 @@ type V1InventoryItem = BaseInventoryItem & {
   sockets: number;
   gfx: number;
   color: number;
+  lvlreq: number;
+  strreq: number;
+  dexreq: number;
 };
 
 type ItemInfo = {
@@ -364,6 +367,18 @@ function buildV1ItemInfo(itemid: string, desc: string) {
     })(),
     gfx: Number(gfx),
     color: Number(color),
+    lvlreq: (() => {
+      const match = desc.match(/Required Level: (\d+)/);
+      return match ? Number(match[1]) : 0;
+    })(),
+    strreq: (() => {
+      const match = desc.match(/Required Strength: (\d+)/);
+      return match ? Number(match[1]) : 0;
+    })(),
+    dexreq: (() => {
+      const match = desc.match(/Required Dexterity: (\d+)/);
+      return match ? Number(match[1]) : 0;
+    })(),
   };
 }
 


### PR DESCRIPTION
This pull request enhances the inventory item data model by adding support for item stat requirements, and updates the item info builder to extract these values from item descriptions.

**Inventory item requirements support:**

* Added new fields to the `V1InventoryItem` type for required level (`lvlreq`), required strength (`strreq`), and required dexterity (`dexreq`).
* Updated the `buildV1ItemInfo` function to parse and assign the required level, strength, and dexterity from the item description string.