### PR TITLE
[Patch] Display item mode and equipped badge

### DIFF
--- a/src/components/InventoryCard.tsx
+++ b/src/components/InventoryCard.tsx
@@ -154,6 +154,10 @@ export const InventoryCard: React.FC<InventoryCardProps> = memo(({ item }) => {
                     <span className="text-gray-400">ID:</span> {item.id}
                   </div>
                   <div>
+                    <span className="text-gray-400">Mode:</span>{" "}
+                    {item.mode ?? "N/A"}
+                  </div>
+                  <div>
                     <span className="text-gray-400">Code:</span> {item.code}
                   </div>
                   <div>
@@ -288,6 +292,16 @@ export const InventoryCard: React.FC<InventoryCardProps> = memo(({ item }) => {
         >
           <RotateCcw className="w-4 h-4" />
         </button>
+      )}
+
+      {isV2 && item.equipped && (
+        <span
+          className={`absolute top-2 bg-blue-500 text-xs px-2 py-0.5 rounded-full text-white z-10 ${
+            showDebugInfo ? "left-10" : "left-2"
+          }`}
+        >
+          Equipped
+        </span>
       )}
 
       {inCart && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,6 +41,7 @@ type V1InventoryItem = BaseInventoryItem & {
 type ItemInfo = {
   id: number;
   code: string;
+  mode?: number;
   name: string;
   prefix: string | undefined;
   suffix: string | undefined;
@@ -64,6 +65,7 @@ type ItemInfo = {
   ethereal: boolean;
   runeword: boolean;
   stats: Record<string, string | number>;
+  equipped?: boolean;
 };
 
 type V2InventoryItem = BaseInventoryItem & {


### PR DESCRIPTION
This pull request enhances the `InventoryCard` component to display additional item details and status, and updates the `ItemInfo` type to support these new properties. The main improvements are the display of the item's mode, the equipped status indicator, and the necessary type changes to support these features.

**UI Enhancements:**

* Added a new field to display the item's `mode` in the `InventoryCard` component, showing "N/A" when the value is not present.
* Added an "Equipped" badge to the `InventoryCard` UI for items that are equipped and when `isV2` is true, improving visibility of equipped status.

**Type Updates:**

* Updated the `ItemInfo` type in `src/lib/utils.ts` to include an optional `mode` property, allowing the UI to safely access this value.
* Added an optional `equipped` property to the `ItemInfo` type to support tracking and displaying equipped status.